### PR TITLE
Refactor: 상세페이지 컴포넌트 분리 및 페이지 이동 시 쿼리 정보 변경

### DIFF
--- a/src/app/detail/[id]/detail.module.scss
+++ b/src/app/detail/[id]/detail.module.scss
@@ -49,20 +49,3 @@
   gap: 1.25rem;
   flex-wrap: wrap;
 }
-
-.listItem {
-  width: calc((100% - 2.5rem) / 3);
-  border-radius: .5rem;
-  overflow: hidden;
-
-  .listLink {
-    text-decoration: none;
-    color: #333;
-
-    .listTitle {
-      font-size: 1.2rem;
-      font-weight: bold;
-    }
-  }
-}
-

--- a/src/app/detail/[id]/detail.module.scss
+++ b/src/app/detail/[id]/detail.module.scss
@@ -43,9 +43,3 @@
 }
 
 
-.list {
-  display: flex;
-  justify-content: space-between;
-  gap: 1.25rem;
-  flex-wrap: wrap;
-}

--- a/src/app/detail/[id]/page.tsx
+++ b/src/app/detail/[id]/page.tsx
@@ -3,16 +3,17 @@
 import { useRouter, useSearchParams } from 'next/navigation'
 import { IChannelVideo } from '@/type/Api'
 import RelatedVedio from '@/components/detail/RelatedVedio'
+
 import styles from './detail.module.scss'
 
 const Detail = (props: any) => {
   const searchParams = useSearchParams()
-  const getItem = searchParams.get('videoInfo')
-  const getItemInfo = JSON.parse(decodeURIComponent(getItem!))
-  console.log(getItemInfo)
-  const videoData = require(
-    `/public/videos/searchByChannels/search-by-channel-id-${props.params.id}`,
-  ).items
+  const getVideoId = searchParams.get('id')
+  const videoIdData = require(`/public/videos/popular`).items
+  const [getItemInfo] = videoIdData.filter(
+    (e: IChannelVideo) => e.id === getVideoId,
+  )
+
   const router = useRouter()
 
   return (
@@ -25,7 +26,13 @@ const Detail = (props: any) => {
       </header>
 
       <figure className={styles.visual}>
-        <img src={getItemInfo.thumbnails.high.url} alt={getItemInfo.title} />
+        <iframe
+          src={`https://www.youtube.com/embed/${getVideoId}`}
+          width="100%"
+          height="100%"
+          allow="autoplay; encrypted-media"
+          allowFullScreen
+        />
       </figure>
 
       <div className={styles.videoInfo}>
@@ -33,26 +40,19 @@ const Detail = (props: any) => {
           <figure className={styles.videoInfoImgFrame}>
             <img
               className={styles.videoInfoImg}
-              src={getItemInfo.thumbnails.high.url}
-              alt={getItemInfo.title}
+              src={getItemInfo.snippet.thumbnails.high.url}
+              alt={getItemInfo.snippet.title}
             />
           </figure>
         </div>
         <div>
-          <h2 className={styles.videoInfoTitle}>{getItemInfo.title}</h2>
-          <p>{getItemInfo.channelTitle}</p>
-          <p>{getItemInfo.description}</p>
+          <h2 className={styles.videoInfoTitle}>{getItemInfo.snippet.title}</h2>
+          <p>{getItemInfo.snippet.channelTitle}</p>
+          <p>{getItemInfo.snippet.description}</p>
         </div>
       </div>
 
-      <div>
-        <h3>관련된 영상</h3>
-        <ul className={styles.list}>
-          {videoData.map((item: IChannelVideo, idx: number) => (
-            <RelatedVedio key={idx} item={item} />
-          ))}
-        </ul>
-      </div>
+      <RelatedVedio id={props.params.id} />
     </main>
   )
 }

--- a/src/app/detail/[id]/page.tsx
+++ b/src/app/detail/[id]/page.tsx
@@ -1,17 +1,16 @@
 'use client'
 
+import videoIdData from '@public/videos/popular.json'
 import { useRouter, useSearchParams } from 'next/navigation'
-import { IChannelVideo } from '@/type/Api'
+import { IVideo } from '@/type/Api'
 import RelatedVedio from '@/components/detail/RelatedVedio'
-
 import styles from './detail.module.scss'
 
 const Detail = (props: any) => {
   const searchParams = useSearchParams()
   const getVideoId = searchParams.get('id')
-  const videoIdData = require(`/public/videos/popular`).items
-  const [getItemInfo] = videoIdData.filter(
-    (e: IChannelVideo) => e.id === getVideoId,
+  const getItemInfo: IVideo | undefined = videoIdData.items.find(
+    (channel: IVideo) => channel.id === getVideoId,
   )
 
   const router = useRouter()
@@ -25,33 +24,40 @@ const Detail = (props: any) => {
         <h1>나만의 과제 이름</h1>
       </header>
 
-      <figure className={styles.visual}>
-        <iframe
-          src={`https://www.youtube.com/embed/${getVideoId}`}
-          width="100%"
-          height="100%"
-          allow="autoplay; encrypted-media"
-          allowFullScreen
-        />
-      </figure>
-
-      <div className={styles.videoInfo}>
-        <div>
-          <figure className={styles.videoInfoImgFrame}>
-            <img
-              className={styles.videoInfoImg}
-              src={getItemInfo.snippet.thumbnails.high.url}
-              alt={getItemInfo.snippet.title}
+      {getItemInfo ? (
+        <>
+          <figure className={styles.visual}>
+            <iframe
+              src={`https://www.youtube.com/embed/${getVideoId}`}
+              width="100%"
+              height="100%"
+              allow="autoplay; encrypted-media"
+              allowFullScreen
             />
           </figure>
-        </div>
-        <div>
-          <h2 className={styles.videoInfoTitle}>{getItemInfo.snippet.title}</h2>
-          <p>{getItemInfo.snippet.channelTitle}</p>
-          <p>{getItemInfo.snippet.description}</p>
-        </div>
-      </div>
 
+          <div className={styles.videoInfo}>
+            <div>
+              <figure className={styles.videoInfoImgFrame}>
+                <img
+                  className={styles.videoInfoImg}
+                  src={getItemInfo.snippet.thumbnails.high.url}
+                  alt={getItemInfo.snippet.title}
+                />
+              </figure>
+            </div>
+            <div>
+              <h2 className={styles.videoInfoTitle}>
+                {getItemInfo.snippet.title}
+              </h2>
+              <p>{getItemInfo.snippet.channelTitle}</p>
+              <p>{getItemInfo.snippet.description}</p>
+            </div>
+          </div>
+        </>
+      ) : (
+        <div>상세정보 불러오기 실패 🥲</div>
+      )}
       <RelatedVedio id={props.params.id} />
     </main>
   )

--- a/src/app/detail/[id]/page.tsx
+++ b/src/app/detail/[id]/page.tsx
@@ -1,17 +1,18 @@
-"use client"
+'use client'
 
-import Link from 'next/link'
 import { useRouter, useSearchParams } from 'next/navigation'
+import { IChannelVideo } from '@/type/Api'
+import RelatedVedio from '@/components/detail/RelatedVedio'
 import styles from './detail.module.scss'
-import { IVideo  } from '@/type/Api'
-
 
 const Detail = (props: any) => {
-  const searchParams = useSearchParams();
-  const getItem = searchParams.get('videoInfo');
-  const getItemInfo = JSON.parse(decodeURIComponent(getItem!));
-  console.log(getItemInfo);
-  const videoData = require(`/public/videos/searchByChannels/search-by-channel-id-${props.params.id}`).items
+  const searchParams = useSearchParams()
+  const getItem = searchParams.get('videoInfo')
+  const getItemInfo = JSON.parse(decodeURIComponent(getItem!))
+  console.log(getItemInfo)
+  const videoData = require(
+    `/public/videos/searchByChannels/search-by-channel-id-${props.params.id}`,
+  ).items
   const router = useRouter()
 
   return (
@@ -22,13 +23,19 @@ const Detail = (props: any) => {
         </button>
         <h1>나만의 과제 이름</h1>
       </header>
+
       <figure className={styles.visual}>
         <img src={getItemInfo.thumbnails.high.url} alt={getItemInfo.title} />
       </figure>
+
       <div className={styles.videoInfo}>
         <div>
           <figure className={styles.videoInfoImgFrame}>
-            <img className={styles.videoInfoImg} src={getItemInfo.thumbnails.high.url} alt={getItemInfo.title} />
+            <img
+              className={styles.videoInfoImg}
+              src={getItemInfo.thumbnails.high.url}
+              alt={getItemInfo.title}
+            />
           </figure>
         </div>
         <div>
@@ -37,22 +44,12 @@ const Detail = (props: any) => {
           <p>{getItemInfo.description}</p>
         </div>
       </div>
+
       <div>
         <h3>관련된 영상</h3>
         <ul className={styles.list}>
-        {videoData.map((item: IVideo, idx: number) => (
-            <li key={idx} className={styles.listItem}>
-              <Link href={`https://www.youtube.com/watch?v=${item.id.videoId}`} className={styles.listLink}>
-                <figure>
-                  <img src={item.snippet.thumbnails.medium.url} alt={item.snippet.title} />
-                </figure>
-                <div>
-                  <h4 className={styles.listTitle}>{item.snippet.title}</h4>
-                  <p>{item.snippet.channelTitle}</p>
-                  <p>{item.snippet.publishedAt}</p>
-                </div>
-              </Link>
-            </li>
+          {videoData.map((item: IChannelVideo, idx: number) => (
+            <RelatedVedio key={idx} item={item} />
           ))}
         </ul>
       </div>
@@ -60,4 +57,4 @@ const Detail = (props: any) => {
   )
 }
 
-export default Detail;
+export default Detail

--- a/src/app/mainList/page.tsx
+++ b/src/app/mainList/page.tsx
@@ -1,51 +1,47 @@
 import Link from 'next/link'
-import { NextPage } from 'next';
+import { NextPage } from 'next'
 import styles from '@/app/mainList/page.module.scss'
 import React from 'react'
 import VIDEO_LIST from '@public/videos/popular.json'
 import formatRelativeDate from '@/utils/relativeDate'
 import axios from 'axios'
-import { IVideo,ISnippet  } from '@/type/Api';
+import { IVideo } from '@/type/Api'
 
 type VideoList = IVideo[]
 
-const VideoListPage:NextPage<ISnippet> = (): React.JSX.Element => {
+const VideoListPage = (): React.JSX.Element => {
   const videoList: VideoList = VIDEO_LIST.items
-  console.log(videoList)
   return (
     <div>
       <ul className={styles.videoList}>
-        {videoList.map((video: IVideo) => {
-          const VIDEO = video.snippet
+        {videoList.map((video: IVideo, idx: number) => {
           return (
-            <li className={styles.videoCard}>
-              <Link 
-                className={styles.videoLink} 
-                href={
-                  {pathname:`/detail/${VIDEO.channelId}`,
-                   query:{videoInfo: encodeURIComponent(JSON.stringify(VIDEO))}
-                   }
-                }
-                // as={`/detail/${VIDEO.channelId}`}
+            <li key={idx} className={styles.videoCard}>
+              <Link
+                className={styles.videoLink}
+                href={{
+                  pathname: `/detail/${video.snippet.channelId}`,
+                  query: { id: video.id },
+                }}
               >
                 <div>
                   <img
                     className={styles.videoImage}
-                    src={VIDEO.thumbnails.medium.url}
+                    src={video.snippet.thumbnails.medium.url}
                     width={300}
                   />
                 </div>
                 <div className={styles.title}>
-                  <h4>{VIDEO.title}</h4>
+                  <h4>{video.snippet.title}</h4>
                 </div>
               </Link>
               <Link className={styles.videoLink} href="">
                 <div className={styles.channelTitle}>
-                  <span>{VIDEO.channelTitle}</span>
+                  <span>{video.snippet.channelTitle}</span>
                 </div>
               </Link>
               <div className={styles.publishedAt}>
-                <span>{formatRelativeDate(VIDEO.publishedAt)}</span>
+                <span>{formatRelativeDate(video.snippet.publishedAt)}</span>
               </div>
             </li>
           )

--- a/src/components/detail/RelatedVedio.module.scss
+++ b/src/components/detail/RelatedVedio.module.scss
@@ -1,3 +1,10 @@
+.list {
+  display: flex;
+  justify-content: space-between;
+  gap: 1.25rem;
+  flex-wrap: wrap;
+}
+
 .listItem {
   width: calc((100% - 2.5rem) / 3);
   border-radius: .5rem;

--- a/src/components/detail/RelatedVedio.module.scss
+++ b/src/components/detail/RelatedVedio.module.scss
@@ -1,0 +1,16 @@
+.listItem {
+  width: calc((100% - 2.5rem) / 3);
+  border-radius: .5rem;
+  overflow: hidden;
+
+  .listLink {
+    text-decoration: none;
+    color: #333;
+
+    .listTitle {
+      font-size: 1.2rem;
+      font-weight: bold;
+    }
+  }
+}
+

--- a/src/components/detail/RelatedVedio.tsx
+++ b/src/components/detail/RelatedVedio.tsx
@@ -1,12 +1,26 @@
-import React from 'react'
+import React, { useState, useEffect } from 'react'
+import axios from 'axios'
 import Link from 'next/link'
 import { IChannelVideo } from '@/type/Api'
 import styles from './RelatedVedio.module.scss'
 
 const RelatedVedio = ({ id }: { id: string }) => {
-  const videoData = require(
-    `/public/videos/searchByChannels/search-by-channel-id-${id}`,
-  ).items
+  const [videoData, setVideoData] = useState<IChannelVideo[]>([])
+
+  useEffect(() => {
+    const fetchData = async () => {
+      try {
+        const response = await axios.get(
+          `/videos/searchByChannels/search-by-channel-id-${id}.json`,
+        )
+        setVideoData(response.data.items)
+      } catch (error) {
+        console.error('Failed to fetch video data', error)
+      }
+    }
+
+    fetchData()
+  }, [id])
 
   return (
     <section>

--- a/src/components/detail/RelatedVedio.tsx
+++ b/src/components/detail/RelatedVedio.tsx
@@ -1,3 +1,5 @@
+'use client'
+
 import React, { useState, useEffect } from 'react'
 import axios from 'axios'
 import Link from 'next/link'

--- a/src/components/detail/RelatedVedio.tsx
+++ b/src/components/detail/RelatedVedio.tsx
@@ -3,26 +3,37 @@ import Link from 'next/link'
 import { IChannelVideo } from '@/type/Api'
 import styles from './RelatedVedio.module.scss'
 
-const RelatedVedio = ({ item }: { item: IChannelVideo }) => {
+const RelatedVedio = ({ id }: { id: string }) => {
+  const videoData = require(
+    `/public/videos/searchByChannels/search-by-channel-id-${id}`,
+  ).items
+
   return (
-    <li className={styles.listItem}>
-      <Link
-        href={`https://www.youtube.com/watch?v=${item.id.videoId}`}
-        className={styles.listLink}
-      >
-        <figure>
-          <img
-            src={item.snippet.thumbnails.medium.url}
-            alt={item.snippet.title}
-          />
-        </figure>
-        <div>
-          <h4 className={styles.listTitle}>{item.snippet.title}</h4>
-          <p>{item.snippet.channelTitle}</p>
-          <p>{item.snippet.publishedAt}</p>
-        </div>
-      </Link>
-    </li>
+    <section>
+      <h3>관련된 영상</h3>
+      <ul className={styles.list}>
+        {videoData.map((item: IChannelVideo, idx: number) => (
+          <li key={idx} className={styles.listItem}>
+            <Link
+              href={`https://www.youtube.com/watch?v=${item.id.videoId}`}
+              className={styles.listLink}
+            >
+              <figure>
+                <img
+                  src={item.snippet.thumbnails.medium.url}
+                  alt={item.snippet.title}
+                />
+              </figure>
+              <div>
+                <h4 className={styles.listTitle}>{item.snippet.title}</h4>
+                <p>{item.snippet.channelTitle}</p>
+                <p>{item.snippet.publishedAt}</p>
+              </div>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </section>
   )
 }
 

--- a/src/components/detail/RelatedVedio.tsx
+++ b/src/components/detail/RelatedVedio.tsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import Link from 'next/link'
+import { IChannelVideo } from '@/type/Api'
+import styles from './RelatedVedio.module.scss'
+
+const RelatedVedio = ({ item }: { item: IChannelVideo }) => {
+  return (
+    <li className={styles.listItem}>
+      <Link
+        href={`https://www.youtube.com/watch?v=${item.id.videoId}`}
+        className={styles.listLink}
+      >
+        <figure>
+          <img
+            src={item.snippet.thumbnails.medium.url}
+            alt={item.snippet.title}
+          />
+        </figure>
+        <div>
+          <h4 className={styles.listTitle}>{item.snippet.title}</h4>
+          <p>{item.snippet.channelTitle}</p>
+          <p>{item.snippet.publishedAt}</p>
+        </div>
+      </Link>
+    </li>
+  )
+}
+
+export default RelatedVedio

--- a/src/type/Api.ts
+++ b/src/type/Api.ts
@@ -50,3 +50,15 @@ export interface IVideo {
   id: string
   snippet: ISnippet
 }
+
+export interface IId {
+  kind: string
+  videoId: string
+}
+
+export interface IChannelVideo {
+  kind: string
+  etag: string
+  id: IId
+  snippet: ISnippet
+}


### PR DESCRIPTION
### Refactor
- [x] 상세 페이지 리팩토링

### 반영 브랜치
feat/relatedList -> develop

### 변경 사항 <!-- 없으면 안써도 됩니다 -->
- `관련된 영상 목록` 컴포넌트 분리 : RelatedVedio
- 메인리스트에서 상세페이지로 데이터 넘기는 부분 쿼리 정보 변경
  - 객체 전체 전송하던 거 키값만 보내서 받는 페이지에서 데이터 불러오는 것으로 수정
  - url 짧아졌습니다 !

### 리뷰 받고 싶은 부분
페이지는 서버 컴포넌트, 외에 것들을 클라이언트 컴포넌트로 관리한다 하는데.. 
페이지가 클라이언트가 되어서 고민이네요.. 데이터 받아오는 다른 부분들도 컴포넌트로 분리해야 되는 것일까요?
