### PR TITLE
Refactor : mainList 데이터 요청 응답 코드 리팩토링 및 server , client 컴포넌트 분리 #16

### DIFF
--- a/src/app/mainList/page.tsx
+++ b/src/app/mainList/page.tsx
@@ -1,56 +1,28 @@
-import Link from 'next/link'
-import { NextPage } from 'next'
-import styles from '@/app/mainList/page.module.scss'
-import React from 'react'
 import VIDEO_LIST from '@public/videos/popular.json'
-import formatRelativeDate from '@/utils/relativeDate'
+import { NextPage } from 'next'
+import React from 'react'
 import axios from 'axios'
 import { IVideo, ISnippet } from '@/type/Api'
+import VideoList from '@/components/mainList/VideoList'
 
-type VideoList = IVideo[]
+type VideoListType = IVideo[]
 
-const VideoListPage: NextPage<ISnippet> = (): React.JSX.Element => {
-  // const ACCESS_KEY = process.env.YOUTUBE_API_KEY
-  // const URL = https://youtube.googleapis.com/youtube/v3/videos?part=snippet&chart=mostPopular&maxResults=25&key=${ACCESS_KEY}
-  // const response = await (await axios.get(URL)).data
-  // const videoList: VideoList = response.items
-  const videoList: VideoList = VIDEO_LIST.items
+const getVideoList = async (): Promise<VideoListType> => {
+  const ACCESS_KEY = process.env.YOUTUBE_API_KEY
+  const URL = `https://youtube.googleapis.com/youtube/v3/videos?part=snippet&chart=mostPopular&maxResults=32&key=${ACCESS_KEY}`
+  const response = await (await axios.get(URL)).data.items
+  if (!response) {
+    throw new Error('data is not defined')
+  }
+  return response
+}
+
+const VideoListPage: NextPage<ISnippet> = async () => {
+  const videoList: VideoListType = await getVideoList()
+  //const videoList: VideoListType = VIDEO_LIST.items
   return (
-    <div className={styles.innerBox}>
-      <ul className={styles.videoList}>
-        {videoList.map((video: IVideo, idx: number) => {
-          return (
-            <li key={idx} className={styles.videoCard}>
-              <Link
-                className={styles.videoLink}
-                href={{
-                  pathname: `/detail/${video.snippet.channelId}`,
-                  query: { id: video.id },
-                }}
-              >
-                <div>
-                  <img
-                    className={styles.videoImage}
-                    src={video.snippet.thumbnails.medium.url}
-                    width={300}
-                  />
-                </div>
-                <div className={styles.title}>
-                  <h4>{video.snippet.title}</h4>
-                </div>
-              </Link>
-              <Link className={styles.videoLink} href="">
-                <div className={styles.channelTitle}>
-                  <span>{video.snippet.channelTitle}</span>
-                </div>
-              </Link>
-              <div className={styles.publishedAt}>
-                <span>{formatRelativeDate(video.snippet.publishedAt)}</span>
-              </div>
-            </li>
-          )
-        })}
-      </ul>
+    <div className="inner-box">
+      <VideoList videoList={videoList} />
     </div>
   )
 }

--- a/src/components/mainList/VideoList.tsx
+++ b/src/components/mainList/VideoList.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import React from 'react'
+import styles from '@/app/mainList/page.module.scss'
+import formatRelativeDate from '@/utils/relativeDate'
+import Link from 'next/link'
+import { IVideo } from '@/type/Api'
+
+type VideoListType = IVideo[]
+
+const VideoList = ({ videoList }: { videoList: VideoListType }) => {
+  return (
+    <>
+      <ul className={styles.videoList}>
+        {videoList.map((video: IVideo) => {
+          const VIDEO = video.snippet
+          return (
+            <li className={styles.videoCard}>
+              <Link
+                className={styles.videoLink}
+                href={{
+                  pathname: `/detail/${VIDEO.channelId}`,
+                  query: {
+                    videoInfo: encodeURIComponent(JSON.stringify(VIDEO)),
+                  },
+                }}
+              >
+                <div>
+                  <img
+                    className={styles.videoImage}
+                    src={VIDEO.thumbnails.medium.url}
+                    width={300}
+                  />
+                </div>
+                <div className={styles.title}>
+                  <h4>{VIDEO.title}</h4>
+                </div>
+              </Link>
+              <Link className={styles.videoLink} href="">
+                <div className={styles.channelTitle}>
+                  <span>{VIDEO.channelTitle}</span>
+                </div>
+              </Link>
+              <div className={styles.publishedAt}>
+                <span>{formatRelativeDate(VIDEO.publishedAt)}</span>
+              </div>
+            </li>
+          )
+        })}
+      </ul>
+    </>
+  )
+}
+
+export default VideoList

--- a/src/components/mainList/VideoList.tsx
+++ b/src/components/mainList/VideoList.tsx
@@ -15,14 +15,12 @@ const VideoList = ({ videoList }: { videoList: VideoListType }) => {
         {videoList.map((video: IVideo) => {
           const VIDEO = video.snippet
           return (
-            <li className={styles.videoCard}>
+            <li className={styles.videoCard} key={video.id}>
               <Link
                 className={styles.videoLink}
                 href={{
                   pathname: `/detail/${VIDEO.channelId}`,
-                  query: {
-                    videoInfo: encodeURIComponent(JSON.stringify(VIDEO)),
-                  },
+                  query: { id: video.id },
                 }}
               >
                 <div>


### PR DESCRIPTION
- [x] mainList 데이터 요청 응답 코드 리팩토링
- [x] server 와 client 컴포넌트 분리

refactor/list -> develop

서버 컴포넌트를 좀 더 깨끗하게 하기 위해 클라이언트 컴포넌트를 따로 만들었습니다.
api에 요청 하는 로직은 함수로 따로 분류 하였고 함수에서 리턴해 주는 값을 변수에 할당 해서 클라이언트 컴포넌트에 props로 데이터를 전달했습니다
close #16 