### PR TITLE
feat: youtube API 연동 후 조회 불가능할 시 JSON 데이터로 불러오는 기능 추가

### DIFF
--- a/src/app/detail/[id]/RelatedVedio.tsx
+++ b/src/app/detail/[id]/RelatedVedio.tsx
@@ -5,10 +5,7 @@ import Link from 'next/link'
 import { IYoutubeItem } from '@/type/Api'
 import formatRelativeDate from '@/utils/relativeDate'
 import ScrollBtn from '@/components/ScrollBtn'
-import {
-  youtubeApiRequest,
-  youtubeJsonRequest,
-} from '@/utils/apiRequest/youtubeApiRequest'
+import youtubeDataRequest from '@/utils/apiRequest/youtubeApiRequest'
 import styles from './detail.module.scss'
 
 const RelatedVedio = ({ channelId }: { channelId: string }) => {
@@ -16,8 +13,11 @@ const RelatedVedio = ({ channelId }: { channelId: string }) => {
 
   useEffect(() => {
     const fetchData = async () => {
-      const response = await youtubeApiRequest(`&channel_id=${channelId}`, 25)
-      // const response = await youtubeJsonRequest('detail', channelId)
+      const response = await youtubeDataRequest(
+        'detail',
+        `&channel_id=${channelId}`,
+        25,
+      )
       setVideoData(response.items)
     }
 

--- a/src/app/detail/[id]/RelatedVedio.tsx
+++ b/src/app/detail/[id]/RelatedVedio.tsx
@@ -5,7 +5,10 @@ import Link from 'next/link'
 import { IYoutubeItem } from '@/type/Api'
 import formatRelativeDate from '@/utils/relativeDate'
 import ScrollBtn from '@/components/ScrollBtn'
-import { youtubeJsonRequest } from '@/utils/apiRequest/youtubeApiRequest'
+import {
+  youtubeApiRequest,
+  youtubeJsonRequest,
+} from '@/utils/apiRequest/youtubeApiRequest'
 import styles from './detail.module.scss'
 
 const RelatedVedio = ({ channelId }: { channelId: string }) => {
@@ -13,14 +16,8 @@ const RelatedVedio = ({ channelId }: { channelId: string }) => {
 
   useEffect(() => {
     const fetchData = async () => {
-      // const response = await youtubeApiRequest(
-      //   'search',
-      //   `&channel_id=${channelId}`,
-      //   25,
-      // )
-      // setVideoData(response)
-
-      const response = await youtubeJsonRequest('detail', channelId)
+      const response = await youtubeApiRequest(`&channel_id=${channelId}`, 25)
+      // const response = await youtubeJsonRequest('detail', channelId)
       setVideoData(response.items)
     }
 

--- a/src/app/detail/[id]/RelatedVedio.tsx
+++ b/src/app/detail/[id]/RelatedVedio.tsx
@@ -11,19 +11,19 @@ import styles from './detail.module.scss'
 const RelatedVedio = ({ channelId }: { channelId: string }) => {
   const [videoData, setVideoData] = useState<IYoutubeItem[]>([])
 
-  const fetchData = async () => {
-    // const response = await youtubeApiRequest(
-    //   'search',
-    //   `&channel_id=${channelId}`,
-    //   25,
-    // )
-    // setVideoData(response)
-
-    const response = await youtubeJsonRequest('detail', channelId)
-    setVideoData(response.items)
-  }
-
   useEffect(() => {
+    const fetchData = async () => {
+      // const response = await youtubeApiRequest(
+      //   'search',
+      //   `&channel_id=${channelId}`,
+      //   25,
+      // )
+      // setVideoData(response)
+
+      const response = await youtubeJsonRequest('detail', channelId)
+      setVideoData(response.items)
+    }
+
     fetchData()
   }, [channelId])
 

--- a/src/app/detail/[id]/page.tsx
+++ b/src/app/detail/[id]/page.tsx
@@ -1,13 +1,17 @@
 import { IYoutubeItem } from '@/type/Api'
 import RelatedVedio from '@/app/detail/[id]/RelatedVedio'
 import ScrollBtn from '@/components/ScrollBtn'
-import { youtubeJsonRequest } from '@/utils/apiRequest/youtubeApiRequest'
+import {
+  youtubeApiRequest,
+  youtubeJsonRequest,
+} from '@/utils/apiRequest/youtubeApiRequest'
 import styles from './detail.module.scss'
 import DetailHeader from './DetailHeader'
 import CommentList from './CommentList'
 
 const getVideoList = async (getVideoId: string) => {
-  const response = await youtubeJsonRequest()
+  // const response = await youtubeJsonRequest()
+  const response = await youtubeApiRequest()
   return response.items.find(
     (channel: IYoutubeItem) => channel.id.videoId === getVideoId,
   )

--- a/src/app/detail/[id]/page.tsx
+++ b/src/app/detail/[id]/page.tsx
@@ -1,17 +1,13 @@
 import { IYoutubeItem } from '@/type/Api'
 import RelatedVedio from '@/app/detail/[id]/RelatedVedio'
 import ScrollBtn from '@/components/ScrollBtn'
-import {
-  youtubeApiRequest,
-  youtubeJsonRequest,
-} from '@/utils/apiRequest/youtubeApiRequest'
+import youtubeDataRequest from '@/utils/apiRequest/youtubeApiRequest'
 import styles from './detail.module.scss'
 import DetailHeader from './DetailHeader'
 import CommentList from './CommentList'
 
 const getVideoList = async (getVideoId: string) => {
-  // const response = await youtubeJsonRequest()
-  const response = await youtubeApiRequest()
+  const response = await youtubeDataRequest()
   return response.items.find(
     (channel: IYoutubeItem) => channel.id.videoId === getVideoId,
   )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,13 +1,17 @@
 import React from 'react'
 import { IYoutubeItem } from '@/type/Api'
 import VideoList from '@/components/home/VideoList'
-import { youtubeJsonRequest } from '@/utils/apiRequest/youtubeApiRequest'
+import {
+  youtubeJsonRequest,
+  youtubeApiRequest,
+} from '@/utils/apiRequest/youtubeApiRequest'
 import styles from './page.module.scss'
 
 type VideoListType = IYoutubeItem[]
 
 const getVideoList = async (): Promise<VideoListType> => {
-  const response = await youtubeJsonRequest()
+  // const response = await youtubeJsonRequest()
+  const response = await youtubeApiRequest()
 
   return response.items
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,17 +1,13 @@
 import React from 'react'
 import { IYoutubeItem } from '@/type/Api'
 import VideoList from '@/components/home/VideoList'
-import {
-  youtubeJsonRequest,
-  youtubeApiRequest,
-} from '@/utils/apiRequest/youtubeApiRequest'
+import youtubeDataRequest from '@/utils/apiRequest/youtubeApiRequest'
 import styles from './page.module.scss'
 
 type VideoListType = IYoutubeItem[]
 
 const getVideoList = async (): Promise<VideoListType> => {
-  // const response = await youtubeJsonRequest()
-  const response = await youtubeApiRequest()
+  const response = await youtubeDataRequest()
 
   return response.items
 }

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -5,10 +5,7 @@ import { useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import formatRelativeDate from '@/utils/relativeDate'
 import { IYoutubeItem } from '@/type/Api'
-import {
-  youtubeApiRequest,
-  youtubeJsonRequest,
-} from '@/utils/apiRequest/youtubeApiRequest'
+import youtubeDataRequest from '@/utils/apiRequest/youtubeApiRequest'
 import styles from '../page.module.scss'
 
 const Search = (props: any): React.ReactElement => {
@@ -18,8 +15,7 @@ const Search = (props: any): React.ReactElement => {
 
   const handleSearch = async () => {
     if (!search) return
-    const response = await youtubeApiRequest(`&q=${search}`, 25)
-    // const response = await youtubeJsonRequest()
+    const response = await youtubeDataRequest('search', `&q=${search}`, 25)
     const filtered: IYoutubeItem[] = response.items.filter(
       (el: IYoutubeItem): boolean => {
         return el.snippet.title.includes(search || '')

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -5,7 +5,10 @@ import { useSearchParams } from 'next/navigation'
 import Link from 'next/link'
 import formatRelativeDate from '@/utils/relativeDate'
 import { IYoutubeItem } from '@/type/Api'
-import { youtubeJsonRequest } from '@/utils/apiRequest/youtubeApiRequest'
+import {
+  youtubeApiRequest,
+  youtubeJsonRequest,
+} from '@/utils/apiRequest/youtubeApiRequest'
 import styles from '../page.module.scss'
 
 const Search = (props: any): React.ReactElement => {
@@ -14,13 +17,9 @@ const Search = (props: any): React.ReactElement => {
   const [filteredItems, setFilteredItems] = useState<IYoutubeItem[]>([])
 
   const handleSearch = async () => {
-    // if (!search) return
-    // const response = await youtubeApiRequest(
-    //   'search',
-    //   `&q=${search}&type=video`,
-    //   25,
-    // )
-    const response = await youtubeJsonRequest()
+    if (!search) return
+    const response = await youtubeApiRequest(`&q=${search}`, 25)
+    // const response = await youtubeJsonRequest()
     const filtered: IYoutubeItem[] = response.items.filter(
       (el: IYoutubeItem): boolean => {
         return el.snippet.title.includes(search || '')

--- a/src/utils/apiRequest/youtubeApiRequest.ts
+++ b/src/utils/apiRequest/youtubeApiRequest.ts
@@ -1,8 +1,5 @@
 import axios from 'axios'
 
-// https://youtube.googleapis.com/youtube/v3/search?part=snippet&maxResults=30
-// &q=%ED%81%AC%EB%A6%AC%EC%8A%A4%EB%A7%88%EC%8A%A4|%ED%81%AC%EB%A6%AC%EC%8A%A4%EB%A7%88%EC%8A%A4%EC%98%81%ED%99%94&type=video&regionCode=kr&order=rating&videoSyndicated=true&key=AIzaSyDyz5t2oRhfpHEnSrXL3LgZyWrJcvNy86Y
-
 const youtubeApiRequest = async (
   optionalQuery: string = '&q=크리스마스|크리스마스영화',
   maxResults: number = 32,
@@ -12,34 +9,52 @@ const youtubeApiRequest = async (
   const commonQuery = `&regionCode=kr&type=video&order=relevance&videoSyndicated=true&maxResults=${maxResults}`
   const URL = `${baseURL}${commonQuery}${optionalQuery}&key=${ACCESS_KEY}`
 
-  let response
   try {
-    response = await axios.get(URL)
+    const youtubeApiData = await axios.get(URL)
+    return youtubeApiData.data
   } catch (error) {
-    console.error('Error fetching data:', error)
+    console.log('[NOTICE] Youtube API 데이터 요청에 실패했습니다.')
+    // if (error instanceof Error) {
+    //   console.error(error.message)
+    // }
+    throw error
   }
-
-  if (!response) {
-    throw new Error('data is not defined')
-  }
-
-  return response.data
 }
 
 const youtubeJsonRequest = async (
   apiType: string = 'popular',
-  optionalQuery: string = '&chart=mostPopular',
+  optionalQuery: string = '',
 ) => {
   let jsonData
   if (apiType === 'popular') {
     jsonData = await import('@public/videos/christmas/christmasPopular_v1.json')
   } else {
+    const channelId = optionalQuery.split('=')[1]
     jsonData = await import(
-      `@public/videos/christmas/searchByChannels/search-by-channel-id-${optionalQuery}.json`
+      `@public/videos/christmas/searchByChannels/search-by-channel-id-${channelId}.json`
     )
   }
 
   return jsonData.default
 }
 
-export { youtubeApiRequest, youtubeJsonRequest }
+const youtubeDataRequest = async (
+  apiType: string = 'popular',
+  optionalQuery: string = '&q=크리스마스|크리스마스영화',
+  maxResults: number = 32,
+) => {
+  let youtubeData
+  try {
+    youtubeData = await youtubeApiRequest(optionalQuery, maxResults)
+  } catch (error) {
+    console.log('[NOTICE] API 요청 횟수 초과. JSON 데이터로 대체합니다.')
+    // if (error instanceof Error) {
+    //   console.error(error.message)
+    // }
+    youtubeData = await youtubeJsonRequest(apiType, optionalQuery)
+  }
+
+  return youtubeData
+}
+
+export default youtubeDataRequest

--- a/src/utils/apiRequest/youtubeApiRequest.ts
+++ b/src/utils/apiRequest/youtubeApiRequest.ts
@@ -1,13 +1,17 @@
 import axios from 'axios'
 
+// https://youtube.googleapis.com/youtube/v3/search?part=snippet&maxResults=30
+// &q=%ED%81%AC%EB%A6%AC%EC%8A%A4%EB%A7%88%EC%8A%A4|%ED%81%AC%EB%A6%AC%EC%8A%A4%EB%A7%88%EC%8A%A4%EC%98%81%ED%99%94&type=video&regionCode=kr&order=rating&videoSyndicated=true&key=AIzaSyDyz5t2oRhfpHEnSrXL3LgZyWrJcvNy86Y
+
 const youtubeApiRequest = async (
-  apiType: string = 'popular',
-  optionalQuery: string = '&chart=mostPopular',
+  optionalQuery: string = '&q=크리스마스|크리스마스영화',
   maxResults: number = 32,
 ) => {
   const ACCESS_KEY = process.env.NEXT_PUBLIC_YOUTUBE_API_KEY
-  const BASIC_URL = `https://youtube.googleapis.com/youtube/v3/${apiType}?part=snippet&regionCode=kr`
-  const URL = `${BASIC_URL}${optionalQuery}&maxResults=${maxResults}&key=${ACCESS_KEY}`
+  const baseURL = `https://youtube.googleapis.com/youtube/v3/search?part=snippet`
+  const commonQuery = `&regionCode=kr&type=video&order=relevance&videoSyndicated=true&maxResults=${maxResults}`
+  const URL = `${baseURL}${commonQuery}${optionalQuery}&key=${ACCESS_KEY}`
+
   let response
   try {
     response = await axios.get(URL)
@@ -19,7 +23,7 @@ const youtubeApiRequest = async (
     throw new Error('data is not defined')
   }
 
-  return response.data.items
+  return response.data
 }
 
 const youtubeJsonRequest = async (

--- a/src/utils/apiRequest/youtubeApiRequest.ts
+++ b/src/utils/apiRequest/youtubeApiRequest.ts
@@ -1,5 +1,8 @@
 import axios from 'axios'
 
+// 리렌더링시 오류메세지 지속적으로 표시되는 문제를 줄이기 위한 전역변수
+let isErrorMessageShown = false
+
 const youtubeApiRequest = async (
   optionalQuery: string = '&q=크리스마스|크리스마스영화',
   maxResults: number = 32,
@@ -14,6 +17,7 @@ const youtubeApiRequest = async (
     return youtubeApiData.data
   } catch (error) {
     console.log('[NOTICE] Youtube API 데이터 요청에 실패했습니다.')
+    isErrorMessageShown = true
     // if (error instanceof Error) {
     //   console.error(error.message)
     // }
@@ -48,9 +52,6 @@ const youtubeDataRequest = async (
     youtubeData = await youtubeApiRequest(optionalQuery, maxResults)
   } catch (error) {
     console.log('[NOTICE] API 요청 횟수 초과. JSON 데이터로 대체합니다.')
-    // if (error instanceof Error) {
-    //   console.error(error.message)
-    // }
     youtubeData = await youtubeJsonRequest(apiType, optionalQuery)
   }
 


### PR DESCRIPTION
### 주요 기능
youtube API 연동 후 조회 불가능할 시 JSON 데이터로 불러오는 기능 추가

### 진행 사항
- [x] youtube API 크리스마스 데이터 불러오는 것으로 수정
- [x] 조회 불가능할 시 json 데이터로 수정

### 이슈
추후 이슈 수정 필요‼️
- 동영상 description 요약으로 나오는 이슈 발생..
- youtube 데이터 요청 실패시 console 창에 오류 메시지 지속적으로 발생..

### 반영 브랜치
feat/api -> develop

