### PR TITLE
fix :  실시간 채팅 새로고침 에러 및 인증 문제 해결

### DIFF
--- a/src/app/(meetUp)/live/_components/LiveChat.tsx
+++ b/src/app/(meetUp)/live/_components/LiveChat.tsx
@@ -2,17 +2,14 @@
 import React, { useEffect, useState, useRef } from 'react'
 import styles from '../live.module.scss'
 import ISupabase from '@/type/SupabaseResponse'
-import { createChat, supabase } from '@/utils/apiRequest/commentsApiRequest'
+import {
+  createChat,
+  supabase,
+  getChat,
+} from '@/utils/apiRequest/commentsApiRequest'
 import { RealtimePostgresInsertPayload } from '@supabase/supabase-js'
-const LiveChat = ({
-  chatData,
-
-  meetupId,
-}: {
-  chatData: ISupabase[]
-  meetupId: string
-}) => {
-  const [chat, setChat] = useState<ISupabase[]>([...chatData])
+const LiveChat = ({ meetupId }: { meetupId: string }) => {
+  const [chat, setChat] = useState<any>([])
   const inputValue = useRef()
   const userData =
     typeof window !== undefined &&
@@ -20,6 +17,16 @@ const LiveChat = ({
   const userItem = userData && JSON.parse(userData).user
 
   console.log(userData && JSON.parse(userData))
+  const fetchChat = async () => {
+    const chatData = await getChat(meetupId)
+    if (chatData) {
+      setChat(chatData)
+    }
+  }
+
+  useEffect(() => {
+    fetchChat()
+  }, [])
   useEffect(() => {
     const checkInsertLive = supabase
       .channel('table-db-changes')
@@ -31,14 +38,14 @@ const LiveChat = ({
           table: 'live_chat',
         },
 
-        (payload: any) => setChat([...chat, payload.new]),
+        () => fetchChat(),
       )
       .subscribe()
 
     return () => {
       supabase.removeChannel(checkInsertLive)
     }
-  }, [supabase, chat, setChat])
+  }, [chat])
 
   const profiles = ['santa', 'snowman', 'candle', 'cookie']
 

--- a/src/app/(meetUp)/live/page.tsx
+++ b/src/app/(meetUp)/live/page.tsx
@@ -1,20 +1,15 @@
 import React from 'react'
 import LiveStream from './_components/LiveStream'
 import styles from './live.module.scss'
-import {
-  getChat,
-  getLive,
-  supabase,
-} from '@/utils/apiRequest/commentsApiRequest'
+import { getLive } from '@/utils/apiRequest/commentsApiRequest'
 import DetailHeader from '../detail/[id]/_components/DetailHeader'
 import dynamic from 'next/dynamic'
-const ComponentsWithNoSSR = dynamic<{ chatData: any; meetupId: any }>( // typescript에서 props를 전달할때 interface를 정의해줍니다.
+const ComponentsWithNoSSR = dynamic<{ meetupId: any }>( // typescript에서 props를 전달할때 interface를 정의해줍니다.
   () => import('./_components/LiveChat'), // Component로 사용할 항목을 import합니다.
   { ssr: false }, // ssr옵션을 false로 설정해줍니다.
 )
 const LivePage = async (param: any) => {
   const currentMeetupId = param.searchParams.meetup_id
-  const chatData = await getChat(currentMeetupId)
   const meetupData = await getLive(currentMeetupId)
   return (
     <div className="inner-box">
@@ -26,7 +21,7 @@ const LivePage = async (param: any) => {
         </div>
         <div className={styles.liveBox}>
           <LiveStream videoId={meetupData.video_id} />
-          <ComponentsWithNoSSR chatData={chatData} meetupId={currentMeetupId} />
+          <ComponentsWithNoSSR meetupId={currentMeetupId} />
         </div>
       </div>
     </div>


### PR DESCRIPTION
### 주요 기능
실시간 채팅 새로고침 하면 데이터 날아가는 문제 해결 및 로그인 했을 때 로그인 유저만 사용할 수 있도록 하는 인증 문제 해결

### 진행 사항
- [ x ] 실시간 채팅 새로고침 하면 데이터 날아가는 문제
- [ x ] 로그인 했을 때 로그인 유저만 사용할 수 있도록 하는 인증 문제

### 반영 브랜치
feat/supaLoginTest -> develop

close #104