### PR TITLE
add/style : 모달data에 videoId,thumbnailUrl 추가 및 버튼 스타일 수정

### DIFF
--- a/src/app/(meetUp)/@createMeetupModal/(.)detail/[id]/meetupModal/_components/_datePicker/DatePicker.tsx
+++ b/src/app/(meetUp)/@createMeetupModal/(.)detail/[id]/meetupModal/_components/_datePicker/DatePicker.tsx
@@ -7,20 +7,10 @@ import 'react-calendar/dist/Calendar.css'
 import 'react-clock/dist/Clock.css'
 import '@/app/datepicker.scss'
 
-type ValuePiece = Date | null
-
-type Value = ValuePiece | [ValuePiece, ValuePiece]
-
-function DatePicker() {
-  const [value, setValue] = useState<Value>(new Date())
-
-  const onChangeValue = (event: ValuePiece) => {
-    setValue(event)
-    console.log(value)
-  }
+const DatePicker = ({ meetupScheduling, onChangeValue }: any) => {
   return (
     <div>
-      <DateTimePicker onChange={onChangeValue} value={value} />
+      <DateTimePicker onChange={onChangeValue} value={meetupScheduling} />
     </div>
   )
 }

--- a/src/app/(meetUp)/@createMeetupModal/(.)detail/[id]/meetupModal/_components/_meetupModal/MeetupModal.tsx
+++ b/src/app/(meetUp)/@createMeetupModal/(.)detail/[id]/meetupModal/_components/_meetupModal/MeetupModal.tsx
@@ -1,17 +1,40 @@
 'use client'
-import React, { useEffect, useRef, useState } from 'react'
+import React, { FormEvent, useEffect, useRef, useState } from 'react'
 import styles from './meetupModal.module.scss'
 import { useRouter } from 'next/navigation'
 import DatePicker from '../_datePicker/DatePicker'
+import { supabase } from '@/utils/apiRequest/defaultApiSetting'
+import { User } from '@supabase/supabase-js'
+import { createMeetupBoard } from '@/utils/apiRequest/meetupApiRequest'
+
+type ValuePiece = Date | null
+type Value = ValuePiece | [ValuePiece, ValuePiece]
+
+export interface IMeetupBoardData {
+  category: string
+  meetup_title: string
+  meetup_content: string
+  scheduling: Value
+  user_name: string
+}
 
 const MeetupModal = (): React.JSX.Element => {
   const router = useRouter()
   const modalRef = useRef<null>(null)
+  const [meetupCategory, setMeetupCategory] = useState<string>('')
   const [meetupTitle, setMeetupTitle] = useState<string>('')
-  const [meetupScheduling, setMeetupScheduling] = useState<string>('')
+  const [meetupScheduling, setMeetupScheduling] = useState<Value>(new Date())
   const [meetupContent, setMeetupContent] = useState<string>('')
+  const [user, setUser] = useState<User>()
 
-  const onClickOutside = (
+  const getUserName = async () => {
+    const {
+      data: { session },
+    } = await supabase.auth.getSession()
+    setUser(session?.user)
+  }
+
+  const handleClickOutside = (
     event: React.MouseEvent<HTMLDivElement, MouseEvent>,
   ): void => {
     if (modalRef.current === event.target) {
@@ -19,9 +42,53 @@ const MeetupModal = (): React.JSX.Element => {
     }
   }
 
+  const onChangeValue = (event: ValuePiece) => {
+    setMeetupScheduling(event)
+  }
+
+  const renderCategoryOption = (): React.JSX.Element[] => {
+    const options = [
+      '카테고리',
+      '영화',
+      '전시회',
+      '여행',
+      '음식',
+      '공연',
+      '음악',
+    ]
+    return options.map((item, index) => {
+      return (
+        <option key={index} value={item}>
+          {item}
+        </option>
+      )
+    })
+  }
+
+  const handleSubmitCreateMeetupBoard = async (event: FormEvent) => {
+    event.preventDefault()
+
+    const data: IMeetupBoardData = {
+      category: meetupCategory,
+      meetup_title: meetupTitle,
+      meetup_content: meetupContent,
+      scheduling: meetupScheduling,
+      user_name: user?.user_metadata.user_name,
+    }
+
+    try {
+      await createMeetupBoard(data)
+      alert('모임 생성 완료!')
+      router.back()
+    } catch (error) {
+      console.log(error)
+    }
+  }
+
   useEffect(() => {
     // 모달이 열릴 때 body의 overflow를 hidden으로 설정
     document.body.style.overflow = 'hidden'
+    getUserName()
 
     return () => {
       // 모달이 닫힐 때 body의 overflow를 초기 상태로 복원
@@ -33,23 +100,21 @@ const MeetupModal = (): React.JSX.Element => {
     <div
       className={styles.modalBackground}
       ref={modalRef}
-      onClick={onClickOutside}
+      onClick={handleClickOutside}
     >
       <div className={styles.modal}>
         <div className={styles.modalHeader}>
           <h1>모임 만들기</h1>
         </div>
-        <form>
+        <form onSubmit={handleSubmitCreateMeetupBoard}>
           <div className={styles.modalBody}>
             <div className={styles.row}>
               <div className={styles.inputDiv}>
-                <select className={styles.category}>
-                  <option>카테고리</option>
-                  <option>영화</option>
-                  <option>전시회</option>
-                  <option>여행</option>
-                  <option>음식</option>
-                  <option>공연</option>
+                <select
+                  className={styles.category}
+                  onChange={event => setMeetupCategory(event.target.value)}
+                >
+                  {renderCategoryOption()}
                 </select>
               </div>
               <div className={styles.inputDiv}>
@@ -63,7 +128,10 @@ const MeetupModal = (): React.JSX.Element => {
             </div>
 
             <div className={styles.inputDiv}>
-              <DatePicker />
+              <DatePicker
+                meetupScheduling={meetupScheduling}
+                onChangeValue={onChangeValue}
+              />
             </div>
 
             <div className={styles.inputDiv}>

--- a/src/app/(meetUp)/@createMeetupModal/(.)detail/[id]/meetupModal/_components/_meetupModal/MeetupModal.tsx
+++ b/src/app/(meetUp)/@createMeetupModal/(.)detail/[id]/meetupModal/_components/_meetupModal/MeetupModal.tsx
@@ -157,7 +157,10 @@ const MeetupModal = ({
             <button
               type="button"
               className={styles.actionButton}
-              onClick={() => router.back()}
+              onClick={() => {
+                removeThumbnailUrl()
+                router.back()
+              }}
             >
               취소
             </button>

--- a/src/app/(meetUp)/@createMeetupModal/(.)detail/[id]/meetupModal/_components/_meetupModal/MeetupModal.tsx
+++ b/src/app/(meetUp)/@createMeetupModal/(.)detail/[id]/meetupModal/_components/_meetupModal/MeetupModal.tsx
@@ -4,7 +4,6 @@ import styles from './meetupModal.module.scss'
 import { useRouter } from 'next/navigation'
 import DatePicker from '../_datePicker/DatePicker'
 import { supabase } from '@/utils/apiRequest/defaultApiSetting'
-import { User } from '@supabase/supabase-js'
 import { createMeetupBoard } from '@/utils/apiRequest/meetupApiRequest'
 import useStore from '@/status/store'
 
@@ -16,7 +15,7 @@ export interface IMeetupBoardData {
   meetup_title: string
   meetup_content: string
   scheduling: Value
-  user_name: string
+  user_name: string | undefined
   video_id: string
   thumbnail: string
 }
@@ -33,13 +32,13 @@ const MeetupModal = ({
   const [meetupTitle, setMeetupTitle] = useState<string>('')
   const [meetupScheduling, setMeetupScheduling] = useState<Value>(new Date())
   const [meetupContent, setMeetupContent] = useState<string>('')
-  const [user, setUser] = useState<User>()
+  const [userName, setUserName] = useState<string | undefined>()
 
   const getUserName = async () => {
     const {
-      data: { session },
-    } = await supabase.auth.getSession()
-    setUser(session?.user)
+      data: { user },
+    } = await supabase.auth.getUser()
+    setUserName(user?.user_metadata.user_name)
   }
 
   const handleClickOutside = (
@@ -81,7 +80,7 @@ const MeetupModal = ({
       meetup_title: meetupTitle,
       meetup_content: meetupContent,
       scheduling: meetupScheduling,
-      user_name: user?.user_metadata.user_name,
+      user_name: userName,
       video_id: currentVideoId,
       thumbnail: videoThumbnailUrl,
     }

--- a/src/app/(meetUp)/@createMeetupModal/(.)detail/[id]/meetupModal/_components/_meetupModal/MeetupModal.tsx
+++ b/src/app/(meetUp)/@createMeetupModal/(.)detail/[id]/meetupModal/_components/_meetupModal/MeetupModal.tsx
@@ -6,6 +6,7 @@ import DatePicker from '../_datePicker/DatePicker'
 import { supabase } from '@/utils/apiRequest/defaultApiSetting'
 import { User } from '@supabase/supabase-js'
 import { createMeetupBoard } from '@/utils/apiRequest/meetupApiRequest'
+import useStore from '@/status/store'
 
 type ValuePiece = Date | null
 type Value = ValuePiece | [ValuePiece, ValuePiece]
@@ -16,11 +17,18 @@ export interface IMeetupBoardData {
   meetup_content: string
   scheduling: Value
   user_name: string
+  video_id: string
+  thumbnail: string
 }
 
-const MeetupModal = (): React.JSX.Element => {
+const MeetupModal = ({
+  currentVideoId,
+}: {
+  currentVideoId: string
+}): React.JSX.Element => {
   const router = useRouter()
   const modalRef = useRef<null>(null)
+  const { videoThumbnailUrl, removeThumbnailUrl } = useStore()
   const [meetupCategory, setMeetupCategory] = useState<string>('')
   const [meetupTitle, setMeetupTitle] = useState<string>('')
   const [meetupScheduling, setMeetupScheduling] = useState<Value>(new Date())
@@ -74,11 +82,14 @@ const MeetupModal = (): React.JSX.Element => {
       meetup_content: meetupContent,
       scheduling: meetupScheduling,
       user_name: user?.user_metadata.user_name,
+      video_id: currentVideoId,
+      thumbnail: videoThumbnailUrl,
     }
 
     try {
       await createMeetupBoard(data)
       alert('모임 생성 완료!')
+      removeThumbnailUrl()
       router.back()
     } catch (error) {
       console.log(error)

--- a/src/app/(meetUp)/@createMeetupModal/(.)detail/[id]/meetupModal/page.tsx
+++ b/src/app/(meetUp)/@createMeetupModal/(.)detail/[id]/meetupModal/page.tsx
@@ -1,8 +1,23 @@
 import React from 'react'
 import MeetupModal from './_components/_meetupModal/MeetupModal'
 
-const page = (): React.ReactNode => {
-  return <MeetupModal />
+interface IParams {
+  id: string
+}
+
+interface ISearchParams {
+  thumbnailUrl: string
+}
+
+interface IProps {
+  params: IParams
+  searchParams: ISearchParams
+}
+
+const page = (props: IProps): React.ReactNode => {
+  const currentVideoId: string = props.params.id
+
+  return <MeetupModal currentVideoId={currentVideoId} />
 }
 
 export default page

--- a/src/app/(meetUp)/detail/[id]/_components/CommentList.tsx
+++ b/src/app/(meetUp)/detail/[id]/_components/CommentList.tsx
@@ -17,15 +17,18 @@ const randomProfile = Math.round(Math.random() * 3)
 
 const CommentList = ({ getVideoId }: { getVideoId: string }) => {
   const [comments, setComments] = useState<IComment[]>([])
+
   const fetchComments = async () => {
     const totalComments = await getComments(getVideoId)
     if (totalComments) {
       setComments(totalComments)
     }
   }
+
   useEffect(() => {
     fetchComments()
   }, [])
+
   return (
     <div className={styles.comments}>
       <p>댓글 {comments.length}개</p>

--- a/src/app/(meetUp)/detail/[id]/_components/CreateComment.tsx
+++ b/src/app/(meetUp)/detail/[id]/_components/CreateComment.tsx
@@ -4,7 +4,6 @@ import React, { useEffect, useRef, useState } from 'react'
 import { usePathname } from 'next/navigation'
 import { createComments } from '@/utils/apiRequest/commentsApiRequest'
 import { supabase } from '@/utils/apiRequest/defaultApiSetting'
-import { User } from '@supabase/supabase-js'
 
 const CreateComment = ({
   profile,
@@ -17,13 +16,13 @@ const CreateComment = ({
   const paramArr = pathParam.split('/')
   const videoId = paramArr[paramArr.length - 1]
   const inputValue = useRef<HTMLInputElement>(null)
-  const [user, setUser] = useState<User>()
+  const [userName, setUserName] = useState<string | undefined>()
 
   const getUserName = async () => {
     const {
-      data: { session },
-    } = await supabase.auth.getSession()
-    setUser(session?.user)
+      data: { user },
+    } = await supabase.auth.getUser()
+    setUserName(user?.user_metadata.user_name)
   }
 
   const handleCreateCommnet = async (event: KeyboardEvent) => {
@@ -32,7 +31,7 @@ const CreateComment = ({
         await createComments(
           inputValue.current.value,
           videoId,
-          user?.user_metadata.user_name,
+          userName,
           profile,
         )
         inputValue.current.value = ''

--- a/src/app/(meetUp)/detail/[id]/_components/CreateComment.tsx
+++ b/src/app/(meetUp)/detail/[id]/_components/CreateComment.tsx
@@ -1,9 +1,10 @@
 'use client'
 
-import React, { useRef } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { usePathname } from 'next/navigation'
 import { createComments } from '@/utils/apiRequest/commentsApiRequest'
-import IComments from '@/type/SupabaseResponse'
+import { supabase } from '@/utils/apiRequest/defaultApiSetting'
+import { User } from '@supabase/supabase-js'
 
 const CreateComment = ({
   profile,
@@ -16,13 +17,22 @@ const CreateComment = ({
   const paramArr = pathParam.split('/')
   const videoId = paramArr[paramArr.length - 1]
   const inputValue = useRef<HTMLInputElement>(null)
-  const handleCreate = async (e: any) => {
-    if (e.key === 'Enter') {
+  const [user, setUser] = useState<User>()
+
+  const getUserName = async () => {
+    const {
+      data: { session },
+    } = await supabase.auth.getSession()
+    setUser(session?.user)
+  }
+
+  const handleCreateCommnet = async (event: KeyboardEvent) => {
+    if (event.key === 'Enter') {
       if (inputValue?.current?.value) {
         await createComments(
           inputValue.current.value,
           videoId,
-          '기본 사용자',
+          user?.user_metadata.user_name,
           profile,
         )
         inputValue.current.value = ''
@@ -31,13 +41,17 @@ const CreateComment = ({
     }
   }
 
+  useEffect(() => {
+    getUserName()
+  }, [])
+
   return (
     <>
       <input
         ref={inputValue}
         type="text"
         placeholder="댓글을 남겨주세요"
-        onKeyPress={handleCreate}
+        onKeyPress={handleCreateCommnet}
       />
     </>
   )

--- a/src/app/(meetUp)/detail/[id]/_components/CreateMeetUpButton.tsx
+++ b/src/app/(meetUp)/detail/[id]/_components/CreateMeetUpButton.tsx
@@ -1,15 +1,24 @@
 'use client'
 import Link from 'next/link'
 import styles from '../detail.module.scss'
+import useStore from '@/status/store'
 
 const CreateMeetUpButton = ({
   currentVideoId,
+  thumbnailUrl,
 }: {
+  thumbnailUrl: string | undefined
   currentVideoId: string
 }): JSX.Element => {
+  const { setThumbnailUrl } = useStore()
   return (
     <div className={styles.buttonArea}>
-      <Link href={`/detail/${currentVideoId}/meetupModal`}>
+      <Link
+        href={`/detail/${currentVideoId}/meetupModal`}
+        onClick={() => {
+          setThumbnailUrl(thumbnailUrl)
+        }}
+      >
         <button className={styles.createMeetup}>모임 생성</button>
       </Link>
     </div>

--- a/src/app/(meetUp)/detail/[id]/_components/RelatedVedio.tsx
+++ b/src/app/(meetUp)/detail/[id]/_components/RelatedVedio.tsx
@@ -8,7 +8,6 @@ import ScrollBtn from '@/app/(common)/_components/ScrollBtn'
 import useYoutubeDataRequest from '@/hooks/useYoutubeApiRequest'
 import Image from 'next/image'
 import styles from '../detail.module.scss'
-import CreateMeetUpButton from './CreateMeetUpButton'
 
 const RelatedVedio = ({
   currentVideoId,
@@ -70,7 +69,6 @@ const RelatedVedio = ({
 
   return (
     <section>
-      <CreateMeetUpButton currentVideoId={currentVideoId} />
       <ul className={styles.list}>
         {videoData &&
           videoData

--- a/src/app/(meetUp)/detail/[id]/detail.module.scss
+++ b/src/app/(meetUp)/detail/[id]/detail.module.scss
@@ -245,8 +245,14 @@
 }
 
 .buttonArea {
-  padding-left: 12.5rem;
-  margin-bottom: 1rem;
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+
+  button {
+    width: 17rem;
+    text-align: center;
+  }
 }
 
 .createMeetup {
@@ -263,14 +269,17 @@
   }
 }
 
-@media (max-width: 1200px) {
+@media (max-width: 1280px) {
   .buttonArea {
-    padding-left: 1rem;
-    margin-bottom: 1rem;
+    justify-content: center;
+    margin: 2rem 0;
   }
 }
 
 @media (max-width: 768px) {
+  .inputComments {
+    padding-right: 2rem;
+  }
   .visualContainer {
     display: block;
   }
@@ -294,10 +303,6 @@
         height: 20.625rem;
       }
     }
-  }
-
-  .buttonArea {
-    padding-left: 12.5rem;
   }
 }
 

--- a/src/app/(meetUp)/detail/[id]/page.tsx
+++ b/src/app/(meetUp)/detail/[id]/page.tsx
@@ -11,6 +11,7 @@ import CommentList from '@/app/(meetUp)/detail/[id]/_components/CommentList'
 import useYoutubeDataRequest from '@/hooks/useYoutubeApiRequest'
 import styles from './detail.module.scss'
 import DetailHeader from './_components/DetailHeader'
+import CreateMeetUpButton from './_components/CreateMeetUpButton'
 
 const Detail = (props: any) => {
   const currentVideoId: string = props.params.id
@@ -44,6 +45,10 @@ const Detail = (props: any) => {
       {currentVideo && (
         <>
           <DetailHeader title={VIDEO_SNIPPET?.channelTitle} />
+          <CreateMeetUpButton
+            thumbnailUrl={VIDEO_SNIPPET?.thumbnails.medium.url}
+            currentVideoId={currentVideoId}
+          />
           <h1 className={styles.videoInfoTitle}>{VIDEO_SNIPPET?.title}</h1>
           <div className={styles.visualContainer}>
             <div>
@@ -56,10 +61,8 @@ const Detail = (props: any) => {
                   allowFullScreen
                 />
               </figure>
-
               <CommentList getVideoId={currentVideoId} />
             </div>
-
             <RelatedVedio
               currentVideoId={currentVideoId}
               channelId={VIDEO_SNIPPET?.channelId}

--- a/src/app/datepicker.scss
+++ b/src/app/datepicker.scss
@@ -14,7 +14,7 @@
   width: 100%;
   .react-calendar {
     width: 100%;
-    height: 20rem;
+    height: 19rem;
     overflow: scroll;
     padding: 1rem;
     border: none;

--- a/src/status/store.ts
+++ b/src/status/store.ts
@@ -4,8 +4,11 @@ import { persist, createJSONStorage } from 'zustand/middleware'
 interface Store {
   isDark: boolean
   isApiQuotaExhausted: boolean
+  videoThumbnailUrl: string
   toggleDarkMode: (state: boolean) => void
   setQuotaExhausted: () => void
+  setThumbnailUrl: (state: string | undefined) => void
+  removeThumbnailUrl: () => void
 }
 
 const useStore = create<Store>()(
@@ -13,8 +16,14 @@ const useStore = create<Store>()(
     set => ({
       isDark: false,
       isApiQuotaExhausted: false,
+      videoThumbnailUrl: '',
       toggleDarkMode: state => set({ isDark: state }),
       setQuotaExhausted: () => set({ isApiQuotaExhausted: true }),
+      setThumbnailUrl: state => set({ videoThumbnailUrl: state }),
+      removeThumbnailUrl: () => {
+        sessionStorage.removeItem('videoThumbnailUrl')
+        set({ videoThumbnailUrl: '' })
+      },
     }),
     {
       name: 'dark-mode-storage',

--- a/src/utils/apiRequest/commentsApiRequest.ts
+++ b/src/utils/apiRequest/commentsApiRequest.ts
@@ -20,7 +20,7 @@ export const getCommentsById = async (id: number) => {
 export const createComments = async (
   comment_content: string,
   video_id: string,
-  user_name: string,
+  user_name: string | undefined,
   profile_img: number,
 ) => {
   return executeQuery(

--- a/src/utils/apiRequest/meetupApiRequest.ts
+++ b/src/utils/apiRequest/meetupApiRequest.ts
@@ -1,0 +1,9 @@
+import { IMeetupBoardData } from '@/app/(meetUp)/@createMeetupModal/(.)detail/[id]/meetupModal/_components/_meetupModal/MeetupModal'
+import { executeQuery, supabase } from './defaultApiSetting'
+
+export const createMeetupBoard = async (data: IMeetupBoardData) => {
+  return executeQuery(
+    supabase.from('meetup_board').insert([data]),
+    '데이터를 생성하지 못했습니다',
+  )
+}


### PR DESCRIPTION
### 주요 기능
버튼의 위치를 관련영상 컴포넌트 => detail 페이지 로 변경 , 그에 따른 버튼 스타일 수정
props로 비디오id와 썸네일url을 모달로 내려줌. 썸네일url은 params로 하면 브라우저 url이 너무 길어지기 때문에 모달 생성 버튼을 클릭시 zustand에 담아서 세션에 저장, 비디오id는 params로 전달 하고props로 받아 저장.
모달에서 두개의 데이터를 추가적으로 넣어서 db에 저장하도록 변경.
db에 데이터를 추가 하고 나면 세션 초기화
zustand 에서는 썸네일url을 저장,삭제 하는 함수 추가

### 진행 사항
- [ x ] 모달 데이터를 입력 하고 모임을 생성 기능
- [ x ] 버튼 스타일 수정

### 리뷰 받고 싶은 부분 
Modal의 서버컴포넌트 페이지에 props의 타입을 지정해 놓은게 있습니다
props의 타입을 지정하려면 무조건 props의 타입에 맞게 설정을 해야 하는데 사실상 id값만 받아오기만 하긴 해서 
타입을 any로 할지 아님 무슨타입으로 들어오는지 더 알기 쉽게 지금 처럼 갈지 의견좀 주세요 ~


### 반영 브랜치
feat/createMeetup -> develop