### PR TITLE
feat : 댓글 수정 삭제 본인 것만 할 수 있도록 구현 및 비밀 번호 찾기 완료 하면 홈으로 리다이렉트 구현

### DIFF
--- a/src/app/(meetUp)/detail/[id]/_components/Comment.tsx
+++ b/src/app/(meetUp)/detail/[id]/_components/Comment.tsx
@@ -32,7 +32,8 @@ interface ICommentProps {
 }
 
 const Comment = ({ comment, fetchComments }: ICommentProps) => {
-  const { id, user_name, comment_content, profile_img, created_at } = comment
+  const { id, user_id, user_name, comment_content, profile_img, created_at } =
+    comment
 
   const COMMENT_ID: number = id
   const profiles: any[] = [santa, snowman, candle, cookie]
@@ -178,16 +179,19 @@ const Comment = ({ comment, fetchComments }: ICommentProps) => {
           <span>&nbsp;{likeCount}</span>
         </button>
       </div>
-      <p
-        className={
-          isDotMenuVisible
-            ? `${styles.moreBtn} ${styles.active}`
-            : styles.moreBtn
-        }
-        onClick={handleClickDotMenu}
-      >
-        ⋮
-      </p>
+      {userId === user_id && (
+        <p
+          className={
+            isDotMenuVisible
+              ? `${styles.moreBtn} ${styles.active}`
+              : styles.moreBtn
+          }
+          onClick={handleClickDotMenu}
+        >
+          ⋮
+        </p>
+      )}
+
       {isDotMenuVisible && (
         <div className={styles.dotMenu}>
           <button onClick={() => handleClickEditButton()}>수정</button>

--- a/src/app/(sign)/resetpassword/page.tsx
+++ b/src/app/(sign)/resetpassword/page.tsx
@@ -16,7 +16,7 @@ const ResetPasswordPage = () => {
     try {
       await supabase.auth.updateUser({ password: passwordRef.current?.value })
       alert('비밀번호 재설정이 완료되었습니다.')
-      router.refresh()
+      router.push('/')
     } catch (error) {
       alert('비밀번호 재설정 시도 중 오류가 발생하였습니다.')
       throw error
@@ -29,7 +29,9 @@ const ResetPasswordPage = () => {
       <form onSubmit={handleSubmit}>
         <PasswordInput passwordRef={passwordRef} />
         <PasswordCheckInput passwordRef={passwordRef} />
-        <button type="submit">비밀번호 변경 완료</button>
+        <button onMouseEnter={() => router.prefetch('/')} type="submit">
+          비밀번호 변경 완료
+        </button>
       </form>
     </main>
   )


### PR DESCRIPTION
### 주요 기능
-댓글 수정 삭제를 할 수 있는 버튼을 로그인한 유저아이디와 댓글의 유저아이디가 같지 않으면 버튼이 보이지 않도록 구현
-비밀번호를 찾고 수정 완료 하고나면 홈으로 이동 하도록 router 추가

### 진행 사항
- [x] 댓글 수정 삭제를 할 수 있는 버튼을 로그인한 유저아이디와 댓글의 유저아이디가 같지 않으면 버튼이 보이지 않도록 구현
- [x] 비밀번호를 찾고 수정 완료 하고나면 홈으로 이동 하도록 router 추가

### 반영 브랜치
refactor/coderefactor -> develop

close #198