### PR TITLE
fix : user 조회 테이블 profile 테이블로 변경

### DIFF
--- a/src/app/(common)/_components/Profile.tsx
+++ b/src/app/(common)/_components/Profile.tsx
@@ -2,7 +2,11 @@
 
 import React, { useEffect, useRef, useState } from 'react'
 import { createClientComponentClient } from '@supabase/auth-helpers-nextjs'
-import { getProfile, updateProfile } from '@/utils/apiRequest/profileApiRequest'
+import {
+  fetchSession,
+  getProfile,
+  updateProfile,
+} from '@/utils/apiRequest/profileApiRequest'
 import { Database, Tables } from '@/type/supabase'
 import styles from './header.module.scss'
 
@@ -22,11 +26,7 @@ const Profile = ({
 
   useEffect(() => {
     const fetchData = async () => {
-      const supabase = createClientComponentClient<Database>()
-      const {
-        data: { session },
-      } = await supabase.auth.getSession()
-
+      const session = await fetchSession()
       const profile: TProfiles[] = await getProfile(
         'email',
         session!.user.email!,

--- a/src/app/(meetUp)/_components/_meetupModal/_meetupModal/MeetupModal.tsx
+++ b/src/app/(meetUp)/_components/_meetupModal/_meetupModal/MeetupModal.tsx
@@ -35,11 +35,13 @@ const MeetupModal = ({
   const [meetupScheduling, setMeetupScheduling] = useState<Value>(new Date())
   const [meetupContent, setMeetupContent] = useState<string>('')
   const [userName, setUserName] = useState<string | null>('')
+  const [userEmail, setUserEmail] = useState<string | null>('')
   const nowDate = new Date()
 
   const fetchUser = async (): Promise<void> => {
     const userData: Tables<'profiles'> = await getProfileByEmail()
     setUserName(userData?.user_name)
+    setUserEmail(userData?.email)
   }
 
   const handleClickOutside = (
@@ -89,6 +91,7 @@ const MeetupModal = ({
       meetup_content: meetupContent,
       scheduling: meetupScheduling as string,
       user_name: userName,
+      email: userEmail,
       video_id: videoId,
       thumbnail: thumbnailsUrl,
       channel_id: channelId,

--- a/src/app/(meetUp)/_components/_meetupModal/_meetupModal/MeetupModal.tsx
+++ b/src/app/(meetUp)/_components/_meetupModal/_meetupModal/MeetupModal.tsx
@@ -2,13 +2,13 @@
 
 import React, { FormEvent, useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
-import { supabase } from '@/utils/apiRequest/defaultApiSetting'
 import { createMeetupBoard } from '@/utils/apiRequest/meetupApiRequestClient'
 import { Value, ValuePiece } from '@/type/Component'
 import dynamic from 'next/dynamic'
 import { IVideoInfoToCookie } from '@/utils/cookieServer'
 import { Tables } from '@/type/supabase'
 import styles from './meetupModal.module.scss'
+import { getProfileByEmail } from '@/utils/apiRequest/profileApiRequest'
 
 type TMeetupBoardData = Tables<'meetup_board'>
 
@@ -37,11 +37,9 @@ const MeetupModal = ({
   const [userName, setUserName] = useState<string | null>('')
   const nowDate = new Date()
 
-  const getUserName = async (): Promise<void> => {
-    const {
-      data: { user },
-    } = await supabase.auth.getUser()
-    setUserName(user?.user_metadata.user_name)
+  const fetchUser = async (): Promise<void> => {
+    const userData: Tables<'profiles'> = await getProfileByEmail()
+    setUserName(userData?.user_name)
   }
 
   const handleClickOutside = (
@@ -111,7 +109,7 @@ const MeetupModal = ({
   useEffect(() => {
     // 모달이 열릴 때 body의 overflow를 hidden으로 설정
     document.body.style.overflow = 'hidden'
-    getUserName()
+    fetchUser()
     return () => {
       // 모달이 닫힐 때 body의 overflow를 초기 상태로 복원
       document.body.style.overflow = 'auto'

--- a/src/app/(meetUp)/detail/[id]/_components/Comment.tsx
+++ b/src/app/(meetUp)/detail/[id]/_components/Comment.tsx
@@ -25,6 +25,7 @@ import likeOn from '@public/assets/likeOn.svg'
 import { supabase } from '@/utils/apiRequest/defaultApiSetting'
 import { Tables } from '@/type/supabase'
 import styles from '../detail.module.scss'
+import { getProfileByEmail } from '@/utils/apiRequest/profileApiRequest'
 
 interface ICommentProps {
   comment: Tables<'comments'>
@@ -46,10 +47,8 @@ const Comment = ({ comment, fetchComments }: ICommentProps) => {
   const [likeCount, setLikeCount] = useState<number | undefined>(0)
 
   const getUserId = async (): Promise<void> => {
-    const {
-      data: { user },
-    } = await supabase.auth.getUser()
-    setUserId(user?.id)
+    const userData: Tables<'profiles'> = await getProfileByEmail()
+    setUserId(userData?.id)
   }
 
   const handleClickCommentLike = async (): Promise<void> => {

--- a/src/app/(meetUp)/detail/[id]/_components/CommentList.tsx
+++ b/src/app/(meetUp)/detail/[id]/_components/CommentList.tsx
@@ -8,10 +8,10 @@ import cookie from '@public/assets/profile-cookie.svg'
 import Image from 'next/image'
 import { getComments } from '@/utils/apiRequest/commentsApiRequest'
 import { Tables } from '@/type/supabase'
-import { supabase } from '@/utils/apiRequest/defaultApiSetting'
 import styles from '../detail.module.scss'
 import CreateComment from './CreateComment'
 import Comment from './Comment'
+import { getProfileByEmail } from '@/utils/apiRequest/profileApiRequest'
 
 type TCommnets = Tables<'comments'>
 
@@ -26,14 +26,12 @@ const CommentList = ({ getVideoId }: { getVideoId: string }) => {
       setComments(totalComments)
     }
   }
-  const getUserName = async (): Promise<void> => {
-    const {
-      data: { user },
-    } = await supabase.auth.getUser()
-    setUserProfile(user?.user_metadata.profile_img)
+  const fetchUser = async (): Promise<void> => {
+    const userData: Tables<'profiles'> = await getProfileByEmail()
+    setUserProfile(userData?.profile_img!)
   }
   useEffect(() => {
-    getUserName()
+    fetchUser()
     fetchComments()
   }, [])
 

--- a/src/app/(meetUp)/detail/[id]/_components/CreateComment.tsx
+++ b/src/app/(meetUp)/detail/[id]/_components/CreateComment.tsx
@@ -3,7 +3,8 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { usePathname } from 'next/navigation'
 import { createComments } from '@/utils/apiRequest/commentsApiRequest'
-import { supabase } from '@/utils/apiRequest/defaultApiSetting'
+import { Tables } from '@/type/supabase'
+import { getProfileByEmail } from '@/utils/apiRequest/profileApiRequest'
 
 const CreateComment = ({
   profile,
@@ -19,10 +20,8 @@ const CreateComment = ({
   const [userName, setUserName] = useState<string | undefined>('')
 
   const getUserName = async (): Promise<void> => {
-    const {
-      data: { user },
-    } = await supabase.auth.getUser()
-    setUserName(user?.user_metadata.user_name)
+    const userData: Tables<'profiles'> = await getProfileByEmail()
+    setUserName(userData.user_name!)
   }
 
   const handleCreateCommnet = async (

--- a/src/app/(meetUp)/live/_components/LiveButton.tsx
+++ b/src/app/(meetUp)/live/_components/LiveButton.tsx
@@ -7,6 +7,8 @@ import { useRouter } from 'next/navigation'
 import { deleteLive } from '@/utils/apiRequest/liveApiRequest'
 import { supabase } from '@/utils/apiRequest/defaultApiSetting'
 import { IMeetupBoardData } from '@/type/Component'
+import { getProfileByEmail } from '@/utils/apiRequest/profileApiRequest'
+import { Tables } from '@/type/supabase'
 
 const LiveButton = ({ user_name, scheduling, meetup_id }: IMeetupBoardData) => {
   const router = useRouter()
@@ -58,8 +60,8 @@ const LiveButton = ({ user_name, scheduling, meetup_id }: IMeetupBoardData) => {
   }, [])
 
   const fetchUser = async () => {
-    const { data } = await supabase.auth.getSession()
-    setUserName(data.session?.user.user_metadata.user_name)
+    const userData: Tables<'profiles'> = await getProfileByEmail()
+    setUserName(userData.user_name)
   }
 
   const isDeleteMeetup = () => {

--- a/src/app/(meetUp)/live/live.module.scss
+++ b/src/app/(meetUp)/live/live.module.scss
@@ -92,10 +92,12 @@
         .userName {
           color: #999;
           margin: 0 1rem;
+          white-space: nowrap;
         }
         .startTime {
           text-decoration: underline;
           color: #da3017;
+          white-space: pre-wrap;
         }
       }
     }

--- a/src/app/(meetUp)/meetup/_components/MeetupBox.tsx
+++ b/src/app/(meetUp)/meetup/_components/MeetupBox.tsx
@@ -32,14 +32,14 @@ const MeetupBox = ({
   meetup: IMeetupBoardData
   fetchMeetupList: () => void
 }): React.JSX.Element => {
-  const [userName, setUserName] = useState<string>('')
+  const [userEmail, setUserEmail] = useState<string>('')
   const [userId, setUserId] = useState<string>('')
   const [isLiked, setIsLiked] = useState<boolean>(false)
   const [likeCount, setLikeCount] = useState<number | undefined>(0)
 
   const fetchData = async (): Promise<void> => {
     const userData: Tables<'profiles'> = await getProfileByEmail()
-    setUserName(userData?.user_name!)
+    setUserEmail(userData?.email!)
     if (userData.id && meetup.id) {
       const isLike = await getLike(userData.id, meetup.id, 'meetup_like')
       const likeLength: number | undefined = await countLike(
@@ -54,22 +54,22 @@ const MeetupBox = ({
 
   const handleMember = async (
     id: number,
-    user_name: string,
+    email: string,
     status: any,
   ): Promise<void> => {
     const prevMember = await getPrevMember(id)
     if (status.target.innerText === APPLY) {
-      const memberArr = [...prevMember.member_list, userName]
+      const memberArr = [...prevMember.member_list, userEmail]
       if (
-        [...prevMember.member_list].includes(userName) ||
-        user_name.includes(userName)
+        [...prevMember.member_list].includes(userEmail) ||
+        email.includes(userEmail)
       ) {
         return alert('이미 참가하였습니다.')
       }
       await updateMember(id, memberArr)
     } else {
       const memberArr = prevMember.member_list.filter(
-        (member: string) => member !== userName,
+        (member: string) => member !== userEmail,
       )
       await updateMember(id, memberArr)
     }
@@ -117,8 +117,8 @@ const MeetupBox = ({
               <p>{dateFomatter(meetup?.scheduling)} 오픈예정</p>
             )}
 
-            {(meetup?.user_name === userName ||
-              meetup?.member_list?.includes(userName)) && (
+            {(meetup?.email === userEmail ||
+              meetup?.member_list?.includes(userEmail)) && (
               <Link
                 href={`/live?meetup_id=${meetup?.id}`}
                 className={`${btn.button} ${btn.buttonGrayBg}`}
@@ -126,14 +126,14 @@ const MeetupBox = ({
                 라이브 바로가기
               </Link>
             )}
-            {meetup?.user_name !== userName && (
+            {meetup?.email !== userEmail && (
               <button
                 onClick={(e: React.MouseEvent) =>
-                  handleMember(meetup?.id!, meetup?.user_name!, e)
+                  handleMember(meetup?.id!, meetup?.email!, e)
                 }
                 className={`${btn.button} ${btn.buttonRed}`}
               >
-                {[...meetup?.member_list!].includes(userName)
+                {[...meetup?.member_list!].includes(userEmail)
                   ? '신청취소'
                   : APPLY}
               </button>

--- a/src/app/(meetUp)/meetup/_components/MeetupBox.tsx
+++ b/src/app/(meetUp)/meetup/_components/MeetupBox.tsx
@@ -12,7 +12,6 @@ import likeOn from '@public/assets/likeOn.svg'
 import likeOff from '@public/assets/likeOff.svg'
 import styles from '../meetup.module.scss'
 import btn from '@/app/globalButton.module.scss'
-import { supabase } from '@/utils/apiRequest/defaultApiSetting'
 import {
   checkLike,
   createLike,
@@ -21,6 +20,8 @@ import {
   countLike,
 } from '@/utils/apiRequest/likeApiRequest'
 import Image from 'next/image'
+import { getProfileByEmail } from '@/utils/apiRequest/profileApiRequest'
+import { Tables } from '@/type/supabase'
 
 const APPLY = '참가신청'
 
@@ -37,13 +38,10 @@ const MeetupBox = ({
   const [likeCount, setLikeCount] = useState<number | undefined>(0)
 
   const fetchData = async (): Promise<void> => {
-    const {
-      data: { session },
-    } = await supabase.auth.getSession()
-    setUserName(session?.user.user_metadata.user_name)
-    const userId = session?.user?.id
-    if (userId && meetup.id) {
-      const isLike = await getLike(userId, meetup.id, 'meetup_like')
+    const userData: Tables<'profiles'> = await getProfileByEmail()
+    setUserName(userData?.user_name!)
+    if (userData.id && meetup.id) {
+      const isLike = await getLike(userData.id, meetup.id, 'meetup_like')
       const likeLength: number | undefined = await countLike(
         meetup.id,
         'meetup_like',
@@ -51,7 +49,7 @@ const MeetupBox = ({
       setIsLiked(isLike)
       setLikeCount(likeLength)
     }
-    setUserId(session?.user?.id!)
+    setUserId(userData.id)
   }
 
   const handleMember = async (

--- a/src/app/(meetUp)/meetup/_components/MeetupList.tsx
+++ b/src/app/(meetUp)/meetup/_components/MeetupList.tsx
@@ -3,37 +3,12 @@
 import React, { useEffect, useState } from 'react'
 import { getMeetupList } from '@/utils/apiRequest/meetupApiRequestClient'
 import { IMeetupBoardData } from '@/type/Component'
-import { supabase } from '@/utils/apiRequest/defaultApiSetting'
 import MeetupBox from './MeetupBox'
 import TabLoading from '@/app/(meetUp)/meetup/_components/_tab/TabLoading'
-//import likeIcon from '@public/assets/like.svg'
 
 const MeetupList = (): React.JSX.Element => {
-  const [isDotMenuVisible, setIsDotMenuVisible] = useState<boolean>(false)
   const [createdMeetup, setCreatedMeetup] = useState<IMeetupBoardData[]>([])
-  const [userName, setUserName] = useState<string>('')
-  const [isEditing, setIsEditing] = useState<boolean>(false)
   const [isLoading, setIsLoading] = useState<boolean>(false)
-  const handleDotMenu = () => {
-    setIsDotMenuVisible(!isDotMenuVisible)
-
-    // dotMenu에 5초 이상 이벤트가 없으면 다시 닫힘
-    if (!isDotMenuVisible) {
-      setTimeout(() => {
-        setIsDotMenuVisible(false)
-      }, 10000)
-    }
-  }
-  const handleEditButton = () => {
-    setIsDotMenuVisible(!isDotMenuVisible)
-    setIsEditing(true)
-  }
-
-  const handleDeleteButton = async () => {
-    setIsDotMenuVisible(!isDotMenuVisible)
-    // deleteComments(comment.id)
-    // await renderUpdatedComment()
-  }
 
   const fetchMeetupList = async () => {
     setIsLoading(true)
@@ -42,14 +17,8 @@ const MeetupList = (): React.JSX.Element => {
     setIsLoading(false)
   }
 
-  const fetchUser = async (): Promise<void> => {
-    const { data } = await supabase.auth.getSession()
-    setUserName(data.session?.user.user_metadata.user_name)
-  }
-
   useEffect(() => {
     fetchMeetupList()
-    fetchUser()
   }, [])
 
   return (

--- a/src/app/(meetUp)/meetup/_components/MyMeetupList.tsx
+++ b/src/app/(meetUp)/meetup/_components/MyMeetupList.tsx
@@ -2,10 +2,11 @@
 
 import React, { useState, useEffect } from 'react'
 import { IMeetupBoardData } from '@/type/Component'
-import { supabase } from '@/utils/apiRequest/defaultApiSetting'
 import MeetupBox from './MeetupBox'
 import { getMeetupList } from '@/utils/apiRequest/meetupApiRequestClient'
 import TabLoading from '@/app/(meetUp)/meetup/_components/_tab/TabLoading'
+import { getProfileByEmail } from '@/utils/apiRequest/profileApiRequest'
+import { Tables } from '@/type/supabase'
 
 const MyMeetupList = (): React.JSX.Element => {
   const [userName, setUserName] = useState<string>('')
@@ -13,8 +14,8 @@ const MyMeetupList = (): React.JSX.Element => {
   const [isLoading, setIsLoading] = useState<boolean>(false)
 
   const fetchUser = async (): Promise<void> => {
-    const { data } = await supabase.auth.getSession()
-    setUserName(data.session?.user.user_metadata.user_name)
+    const userData: Tables<'profiles'> = await getProfileByEmail()
+    setUserName(userData?.user_name!)
   }
 
   const fetchMeetupList = async (): Promise<void> => {

--- a/src/app/(meetUp)/meetup/_components/MyMeetupList.tsx
+++ b/src/app/(meetUp)/meetup/_components/MyMeetupList.tsx
@@ -10,12 +10,14 @@ import { Tables } from '@/type/supabase'
 
 const MyMeetupList = (): React.JSX.Element => {
   const [userName, setUserName] = useState<string>('')
+  const [userEmail, setUserEmail] = useState<string>('')
   const [createdMeetup, setCreatedMeetup] = useState<never[]>([])
   const [isLoading, setIsLoading] = useState<boolean>(false)
 
   const fetchUser = async (): Promise<void> => {
     const userData: Tables<'profiles'> = await getProfileByEmail()
     setUserName(userData?.user_name!)
+    setUserEmail(userData?.email!)
   }
 
   const fetchMeetupList = async (): Promise<void> => {
@@ -37,8 +39,8 @@ const MyMeetupList = (): React.JSX.Element => {
         createdMeetup
           ?.filter(
             (meetup: IMeetupBoardData) =>
-              meetup?.user_name === userName ||
-              meetup?.member_list?.includes(userName),
+              meetup?.email === userEmail ||
+              meetup?.member_list?.includes(userEmail),
           )
           .map((meetup: IMeetupBoardData) => {
             return (

--- a/src/app/(meetUp)/meetup/layout.tsx
+++ b/src/app/(meetUp)/meetup/layout.tsx
@@ -6,6 +6,7 @@ import { createServerComponentClient } from '@supabase/auth-helpers-nextjs'
 import styles from './meetup.module.scss'
 import MeetupTabButtons from './_components/_tab/MeetupTabButtons'
 import MeetupTabPage from './_components/_tab/MeetupTabPage'
+import { getProfile } from '@/utils/apiRequest/profileApiRequest'
 
 const MeetupLayout = async (props: any): Promise<React.JSX.Element> => {
   const cookieStore = cookies()
@@ -14,7 +15,8 @@ const MeetupLayout = async (props: any): Promise<React.JSX.Element> => {
   })
 
   const { data } = await supabase.auth.getSession()
-  const userName: string = data.session?.user.user_metadata.user_name
+  const email = data.session?.user?.email
+  const [userData] = await getProfile('email', email!)
 
   return (
     <div className={styles.layout}>
@@ -24,7 +26,7 @@ const MeetupLayout = async (props: any): Promise<React.JSX.Element> => {
       >
         <div className={styles.pageHeader}>
           <div>
-            <h1>안녕하세요, {userName}님</h1>
+            <h1>안녕하세요, {userData.user_name}님</h1>
             <p>촛불 모임에서 친구들과 특별한 크리스마스 추억을 쌓아보세요.</p>
           </div>
         </div>

--- a/src/app/_components/SlotModal.tsx
+++ b/src/app/_components/SlotModal.tsx
@@ -3,6 +3,8 @@
 import React, { useState, useEffect } from 'react'
 import styles from '@/app/page.module.scss'
 import { supabase } from '@/utils/apiRequest/defaultApiSetting'
+import { Tables } from '@/type/supabase'
+import { getProfileByEmail } from '@/utils/apiRequest/profileApiRequest'
 
 declare global {
   interface Window {
@@ -21,7 +23,7 @@ const SlotModal = ({ handleModalClose, sentence }: any) => {
       document.body.style.overflow = 'auto'
     }
   }, [])
-  const getUserName = async (): Promise<void> => {
+  const checkUser = async (): Promise<void> => {
     try {
       const {
         data: { user },
@@ -30,19 +32,19 @@ const SlotModal = ({ handleModalClose, sentence }: any) => {
       if (!user) {
         throw error
       }
-      return user?.user_metadata.user_name
     } catch (error) {
       alert('로그인 후 사용해주세요')
     }
   }
   const handleShare = async () => {
-    const userName = await getUserName()
+    await checkUser()
+    const userData: Tables<'profiles'> = await getProfileByEmail()
     try {
-      if (userName !== undefined) {
+      if (userData.user_name !== undefined) {
         window.Kakao.Share.sendCustom({
           templateId: 102052,
           templateArgs: {
-            tester: userName,
+            tester: userData.user_name,
             result: sentence.join(' '),
           },
         })

--- a/src/app/page.module.scss
+++ b/src/app/page.module.scss
@@ -177,6 +177,7 @@
     h2 {
       font-family: yg-jalnan, sans-serif;
       font-size: 4rem;
+      white-space: nowrap;
       font-weight: 800;
       text-shadow: 2.349px 1.175px 2.349px rgba(0, 0, 0, 0.25);
     }
@@ -850,7 +851,11 @@ html[data-theme='dark'] {
   .bg {
     height: auto;
     z-index: 1;
-    background: linear-gradient(to bottom, var(--color-main-bg) 54%, #fff 46%);
+    background: linear-gradient(
+      to bottom,
+      var(--color-main-bg) 54%,
+      var(--color-main-ground-bg) 46%
+    );
     .snow {
       position: static;
     }
@@ -922,9 +927,9 @@ html[data-theme='dark'] {
       width: 10rem;
       height: 10rem;
       bottom: 3%;
-      margin: 5% 0;
+      padding: 5% 0;
       h2 {
-        font-size: 3.4rem;
+        font-size: 2.5rem;
       }
       h4 {
         font-size: 2rem;

--- a/src/type/Component.ts
+++ b/src/type/Component.ts
@@ -17,6 +17,7 @@ export interface IMeetupBoardData {
   meetup_content?: string
   scheduling: Value
   user_name?: string | undefined
+  email: string
   video_id?: string
   thumbnail?: string
   channel_id?: string

--- a/src/type/supabase.ts
+++ b/src/type/supabase.ts
@@ -146,6 +146,7 @@ export interface Database {
           scheduling: string | null
           thumbnail: string | null
           user_name: string | null
+          email: string | null
           video_id: string | null
           video_title: string | null
         }

--- a/src/utils/apiRequest/profileApiRequest.ts
+++ b/src/utils/apiRequest/profileApiRequest.ts
@@ -48,3 +48,17 @@ export const updateProfile = async ({
     throw new Error(`[ERROR]데이터를 수정하지 못했습니다`)
   }
 }
+
+export const fetchSession = async () => {
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  return session
+}
+
+export const getProfileByEmail = async () => {
+  const session = await fetchSession()
+  const email = session?.user?.email
+  const [userData]: Tables<'profiles'>[] = await getProfile('email', email!)
+  return userData
+}


### PR DESCRIPTION
### 주요 기능
user 조회 테이블 profile 테이블로 변경

### 진행 사항
- [x] 메인 introduce 다크모드 수정
- [x] user 조회 hook 생성
    - [x] 댓글 프로필 설정
    - [x] 촛불모임 - 안녕하세요, ooo 님 부분 수정
    - [x] 촛불모임 - 모임생성모달
    - [x] 촛불모임 -  모임 참가
    - [x] 촛불모임 -  내 모임 조회
    - [x]  댓글 CRUD
    - [x]  라이브 채팅 및 종료 버튼 권한
    - [x]  슬롯 모달
- [x] meetup_board에 email 필드 추가
    - [x] 모임 생성 모달에 조건 추가
    - [x] supabase 타입 email 필드 추가
    - [x] 모임 참가/멤버 관리 에 email 필드 조건 적용

### 반영 브랜치
fix/userData -> develop

close #202
