### PR TITLE
fix: 검색어 재입력시 조회 안되는 오류 수정

### DIFF
--- a/src/app/(common)/search/_components/SearchList.tsx
+++ b/src/app/(common)/search/_components/SearchList.tsx
@@ -1,32 +1,38 @@
 'use client'
 
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import Link from 'next/link'
 import formatRelativeDate from '@/utils/relativeDate'
 import styles from '@/app/page.module.scss'
 import { IYoutubeItem } from '@/type/YoutubeApiResponse'
-import useInfiniteScroll from '@/hooks/useInfiniteScroll'
 import { setVideoInfoToCookie } from '@/utils/cookieClient'
+import { useSearchParams } from 'next/navigation'
+import youtubeRequest from '@/utils/youtubRequest/youtubeRequest'
 
-interface IProps {
-  initialData: IYoutubeItem[] | []
-  keyword: string
-  pageToken: string
-}
+const SearchList = (): React.ReactElement => {
+  const searchParams = useSearchParams()
+  const keyword = searchParams.get('search-keyword')
+  const [searchResult, setSearchResult] = useState<IYoutubeItem[]>([])
 
-const SearchList = ({
-  initialData,
-  keyword,
-  pageToken,
-}: IProps): React.ReactElement => {
-  const searchResult = useInfiniteScroll({
-    pageToken,
-    initialData,
-    optionalQuery: {
-      q: keyword,
-      maxResults: '12',
-    },
-  })
+  useEffect(() => {
+    const getSearchResults = async () => {
+      if (!keyword) return
+      const { itemList } = await youtubeRequest({
+        apiType: 'search',
+        optionalQuery: {
+          q: keyword,
+          maxResults: '20',
+        },
+      })
+      const searchResults = itemList.filter((el: IYoutubeItem): boolean => {
+        return el.snippet.title.includes(keyword)
+      })
+
+      setSearchResult(searchResults)
+    }
+
+    getSearchResults()
+  }, [keyword])
 
   return (
     <div className="inner-box">

--- a/src/app/(common)/search/page.tsx
+++ b/src/app/(common)/search/page.tsx
@@ -7,37 +7,25 @@ import NoResult from './_components/NoResult'
 
 const SearchPage = async () => {
   const getSearchResults = async (keyword: string) => {
-    const { itemList, pageToken = '' } = await youtubeRequest({
+    const { itemList } = await youtubeRequest({
       apiType: 'search',
       optionalQuery: {
         q: keyword,
-        maxResults: '12',
+        maxResults: '20',
       },
     })
     const searchResults = itemList.filter((el: IYoutubeItem): boolean => {
       return el.snippet.title.includes(keyword)
     })
 
-    return { searchResults, pageToken }
+    return { searchResults }
   }
 
   const cookieStore = cookies()
   const keyword = cookieStore.get('search-keyword')?.value
-  const { searchResults, pageToken } = await getSearchResults(keyword!)
+  const { searchResults } = await getSearchResults(keyword!)
 
-  return (
-    <>
-      {searchResults.length ? (
-        <SearchList
-          initialData={searchResults}
-          keyword={keyword as string}
-          pageToken={pageToken}
-        />
-      ) : (
-        <NoResult />
-      )}
-    </>
-  )
+  return <>{searchResults.length ? <SearchList /> : <NoResult />}</>
 }
 
 export default SearchPage


### PR DESCRIPTION
### 주요 기능
검색어 재입력시 조회 안되는 오류 수정

### 진행 사항
- [x] 서버에서 통신하던 키워드 데이러 조회 컴포넌트로 변경

### 참고 사항
서버 컴포넌트와 클라이언트 컴포넌트에 같은 코드가 존재하여 추후 리팩터링 필요

### 반영 브랜치
fix/search -> develop